### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ torchvision
 clip-anytorch
 pyarrow
 pillow
-tf-yarn
+tf-yarn<0.7.0
 wandb
 webdataset==0.1.103
 tqdm


### PR DESCRIPTION
Limit version of tf-yarn as there are 2 breaking changes in the last version: 
- removal of PYTORCH_DDP_RANK usage in favor of explicitly checking rank before checkpointing
- passing number of tasks per container in the TaskSpecs instead of the Experiment